### PR TITLE
feat: Enable feature flag to handle jobs TTL

### DIFF
--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -63,6 +63,7 @@ ${apiserver-runtime-config}
     featureGates:
       ExpandPersistentVolumes: "true"
       PodPriority: "true"
+      TTLAfterFinished: "true"
   kubeControllerManager:
     allocateNodeCIDRs: true
     attachDetachReconcileSyncPeriod: 1m0s
@@ -81,6 +82,7 @@ ${apiserver-runtime-config}
     featureGates:
       ExpandPersistentVolumes: "true"
       PodPriority: "true"
+      TTLAfterFinished: "true"
 
   kubeDNS:
     provider: ${dns-provider}


### PR DESCRIPTION
Hello SRE, I'd like to have a TTL on the k8s jobs. In each deployment, we create database migration jobs which are never deleted. It puts pressure on the K8S controllers because we have hundreds of completed jobs.
To see the consequence, see `kubectx staging && kubens core && kgp` and you'll see the hell

see https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
To work, it needs a feature flag

⚠️  I have no idea how to deploy that, I would need you help for it.